### PR TITLE
Fixed compile warnings for Xcode 7.3.1

### DIFF
--- a/Info.plist
+++ b/Info.plist
@@ -9,7 +9,7 @@
 	<key>CFBundleIconFile</key>
 	<string></string>
 	<key>CFBundleIdentifier</key>
-	<string>com.yourcompany.${PRODUCT_NAME:identifier}</string>
+	<string>$(PRODUCT_BUNDLE_IDENTIFIER)</string>
 	<key>CFBundleInfoDictionaryVersion</key>
 	<string>6.0</string>
 	<key>CFBundleName</key>

--- a/MGScopeBar.xcodeproj/project.pbxproj
+++ b/MGScopeBar.xcodeproj/project.pbxproj
@@ -255,7 +255,7 @@
 		29B97313FDCFA39411CA2CEA /* Project object */ = {
 			isa = PBXProject;
 			attributes = {
-				LastUpgradeCheck = 0420;
+				LastUpgradeCheck = 0730;
 			};
 			buildConfigurationList = C01FCF4E08A954540054247B /* Build configuration list for PBXProject "MGScopeBar" */;
 			compatibilityVersion = "Xcode 3.2";
@@ -353,7 +353,6 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				ALWAYS_SEARCH_USER_PATHS = NO;
-				ARCHS = "$(ARCHS_STANDARD_64_BIT)";
 				CLANG_CXX_LANGUAGE_STANDARD = "gnu++0x";
 				CLANG_ENABLE_OBJC_ARC = YES;
 				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
@@ -378,6 +377,7 @@
 				LD_DYLIB_INSTALL_NAME = "@executable_path/../Frameworks/$(EXECUTABLE_PATH)";
 				MACOSX_DEPLOYMENT_TARGET = 10.9;
 				ONLY_ACTIVE_ARCH = YES;
+				PRODUCT_BUNDLE_IDENTIFIER = "com.qsrinternaltional.${PRODUCT_NAME:rfc1034identifier}";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				WRAPPER_EXTENSION = framework;
 			};
@@ -387,7 +387,6 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				ALWAYS_SEARCH_USER_PATHS = NO;
-				ARCHS = "$(ARCHS_STANDARD_64_BIT)";
 				CLANG_CXX_LANGUAGE_STANDARD = "gnu++0x";
 				CLANG_ENABLE_OBJC_ARC = YES;
 				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
@@ -405,6 +404,7 @@
 				INFOPLIST_FILE = "mgscopebar/mgscopebar-Info.plist";
 				LD_DYLIB_INSTALL_NAME = "@executable_path/../Frameworks/$(EXECUTABLE_PATH)";
 				MACOSX_DEPLOYMENT_TARGET = 10.9;
+				PRODUCT_BUNDLE_IDENTIFIER = "com.qsrinternaltional.${PRODUCT_NAME:rfc1034identifier}";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				WRAPPER_EXTENSION = framework;
 			};
@@ -414,8 +414,8 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				ALWAYS_SEARCH_USER_PATHS = NO;
-				ARCHS = "$(ARCHS_STANDARD_64_BIT)";
 				CLANG_ENABLE_OBJC_ARC = YES;
+				COMBINE_HIDPI_IMAGES = YES;
 				COPY_PHASE_STRIP = NO;
 				GCC_DYNAMIC_NO_PIC = NO;
 				GCC_OPTIMIZATION_LEVEL = 0;
@@ -423,6 +423,7 @@
 				GCC_PREFIX_HEADER = MGScopeBar_Prefix.pch;
 				INFOPLIST_FILE = Info.plist;
 				INSTALL_PATH = "$(HOME)/Applications";
+				PRODUCT_BUNDLE_IDENTIFIER = "com.yourcompany.${PRODUCT_NAME:identifier}";
 				PRODUCT_NAME = MGScopeBar;
 			};
 			name = Debug;
@@ -431,12 +432,13 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				ALWAYS_SEARCH_USER_PATHS = NO;
-				ARCHS = "$(ARCHS_STANDARD_64_BIT)";
 				CLANG_ENABLE_OBJC_ARC = YES;
+				COMBINE_HIDPI_IMAGES = YES;
 				GCC_PRECOMPILE_PREFIX_HEADER = YES;
 				GCC_PREFIX_HEADER = MGScopeBar_Prefix.pch;
 				INFOPLIST_FILE = Info.plist;
 				INSTALL_PATH = "$(HOME)/Applications";
+				PRODUCT_BUNDLE_IDENTIFIER = "com.yourcompany.${PRODUCT_NAME:identifier}";
 				PRODUCT_NAME = MGScopeBar;
 			};
 			name = Release;
@@ -444,13 +446,14 @@
 		C01FCF4F08A954540054247B /* Debug */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
-				ARCHS = "$(ARCHS_STANDARD_32_64_BIT)";
 				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
+				ENABLE_TESTABILITY = YES;
 				GCC_C_LANGUAGE_STANDARD = c99;
 				GCC_OPTIMIZATION_LEVEL = 0;
 				GCC_WARN_ABOUT_RETURN_TYPE = YES;
 				GCC_WARN_UNUSED_VARIABLE = YES;
 				MACOSX_DEPLOYMENT_TARGET = 10.9;
+				ONLY_ACTIVE_ARCH = YES;
 				RUN_CLANG_STATIC_ANALYZER = YES;
 				SDKROOT = macosx;
 			};
@@ -459,7 +462,6 @@
 		C01FCF5008A954540054247B /* Release */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
-				ARCHS = "$(ARCHS_STANDARD_32_64_BIT)";
 				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
 				GCC_C_LANGUAGE_STANDARD = c99;
 				GCC_WARN_ABOUT_RETURN_TYPE = YES;

--- a/MGTrackingButton.h
+++ b/MGTrackingButton.h
@@ -23,7 +23,7 @@
 @property (nonatomic, assign) NSInteger groupNumber;
 
 //! The MGScopeBar identifier for the button
-@property (nonatomic, strong) NSString* identifier;
+@property (nonatomic, readonly) NSString* scopebarIdentifier;
 
 //! The button's mouse event delegate
 @property (nonatomic, assign) id<MGTrackingDelegateProtocol> delegate;

--- a/MGTrackingButton.m
+++ b/MGTrackingButton.m
@@ -7,6 +7,13 @@
 
 #import "MGTrackingButton.h"
 
+@interface MGTrackingButton ()
+
+//! The MGScopeBar identifier for the button
+@property (nonatomic, strong) NSString* scopebarIdentifier;
+
+@end
+
 @implementation MGTrackingButton
 
 - (id)initWithFrame:(NSRect)frame
@@ -20,10 +27,10 @@
 	return self;
 }
 
-- (void)trackMouseMovementsToDelegate:(id<MGTrackingDelegateProtocol>)delegate forIdentifier:(NSString *)identifier inGroup:(NSInteger)groupNumber
+- (void)trackMouseMovementsToDelegate:(id<MGTrackingDelegateProtocol>)delegate forIdentifier:(NSString *)scopebarIdentifier inGroup:(NSInteger)groupNumber
 {
 	[self setDelegate:delegate];
-	[self setIdentifier:identifier];
+	[self setScopebarIdentifier:scopebarIdentifier];
 	[self setGroupNumber:groupNumber];
 
 	[self updateTrackingAreas];
@@ -57,13 +64,13 @@
 //! Called via the tracking area when the cursor enters the tracking area
 - (void)mouseEntered:(NSEvent *)theEvent
 {
-	[_delegate controlDidEnterWithControl:(id)self identifier:[self identifier] andGroupNumber:[self groupNumber]];
+	[_delegate controlDidEnterWithControl:(id)self identifier:[self scopebarIdentifier] andGroupNumber:[self groupNumber]];
 }
 
 //! Called via the tracking area when the cursor leaves the tracking area
 - (void)mouseExited:(NSEvent *)theEvent
 {
-	[_delegate controlDidExitWithControl:(id)self identifier:[self identifier] andGroupNumber:[self groupNumber]];
+	[_delegate controlDidExitWithControl:(id)self identifier:[self scopebarIdentifier] andGroupNumber:[self groupNumber]];
 }
 
 @end

--- a/mgscopebar/mgscopebar-Info.plist
+++ b/mgscopebar/mgscopebar-Info.plist
@@ -9,7 +9,7 @@
 	<key>CFBundleIconFile</key>
 	<string></string>
 	<key>CFBundleIdentifier</key>
-	<string>com.qsrinternaltional.${PRODUCT_NAME:rfc1034identifier}</string>
+	<string>$(PRODUCT_BUNDLE_IDENTIFIER)</string>
 	<key>CFBundleInfoDictionaryVersion</key>
 	<string>6.0</string>
 	<key>CFBundleName</key>


### PR DESCRIPTION
Upgrading to Xcode 7.3.1 introduced a number of warnings to the build, as well as prompts to upgrade to latest settings
- Changed class local 'identifier' var to 'scopebarIdentifier' as later SDKs have introduced 'identifier' as an accessibility trait on UI elements.
